### PR TITLE
README changes for configuring ollama context size

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ By default, the installer configures Ollama with a 4K token limit for optimal pe
 3. Find the line that says `OLLAMA_MODEL_TOKEN_LIMIT=4096` and change `4096` to your desired token limit (e.g., `8192` for 8K tokens).
 4. Save the file and restart the AI using the launcher script `start-windows.bat` or `start-mac.command` or `start-linux.sh`.
 5. Incase if you re-run the installer script `install.bat` or `install.sh` it will reset the token limit back to 4096, so you will need to change it again in the `.env` file.
+6. For mac, you may re-run the `start-mac.command` script and it will not overwrite the token limit in the `.env` file, so you can just restart the AI using this script after changing the token limit in the `.env` file.
 
 ## ▶️ How to Use
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Just **re-run `install.bat`** and select additional models. Already-downloaded m
 
 Want a model not on the list? During install, choose option **C** and paste any direct `.gguf` download link from HuggingFace. The installer handles the rest!
 
+### 🗄️ Configuring Ollama Token Limit / Context Size
+
+By default, the installer configures Ollama with a 4K token limit for optimal performance on most PCs. If you want to adjust this, follow these steps after install script has finished running:
+
+1. Open this folder on your USB drive. `anythingllm_data/storage`
+2. Open the `.env` file in a text editor.
+3. Find the line that says `OLLAMA_MODEL_TOKEN_LIMIT=4096` and change `4096` to your desired token limit (e.g., `8192` for 8K tokens).
+4. Save the file and restart the AI using the launcher script `start-windows.bat` or `start-mac.command` or `start-linux.sh`.
+5. Incase if you re-run the installer script `install.bat` or `install.sh` it will reset the token limit back to 4096, so you will need to change it again in the `.env` file.
+
 ## ▶️ How to Use
 
 ### On Windows


### PR DESCRIPTION
Hey folks,
A small README update, which might help.

By default the context limit set for ollama is 4K tokens (4096) which is good for most PCs
But, if the user wants to reconfigure it to a higher limit, I have added the steps in the readme, which will help them to edit the .env file directly and set the environment variable.

Kindly check