### PR TITLE
fix: Intel Mac support, RAM pre-flight check, TLS revocation, Ollama readiness poll, and model pref update on re-install

### DIFF
--- a/install-core.ps1
+++ b/install-core.ps1
@@ -119,12 +119,27 @@ Write-Host "   PORTABLE AI USB - Multi-Model Setup                    " -Foregro
 Write-Host "==========================================================" -ForegroundColor Cyan
 Write-Host ""
 
-# Show USB free space
+# Show USB free space and system RAM
 $freeGB = Get-USBFreeSpaceGB
 if ($freeGB -gt 0) {
     Write-Host "  USB Free Space: $freeGB GB" -ForegroundColor DarkGray
-    Write-Host ""
 }
+
+$ramGB = -1
+try {
+    $ramGB = [math]::Round((Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop).TotalPhysicalMemory / 1GB, 0)
+} catch {}
+if ($ramGB -gt 0) {
+    Write-Host "  System RAM    : $ramGB GB" -ForegroundColor DarkGray
+    if ($ramGB -lt 4) {
+        Write-Host "  WARNING: $ramGB GB RAM is insufficient. AI models require at least 4 GB." -ForegroundColor Red
+    } elseif ($ramGB -lt 6) {
+        Write-Host "  NOTE: Only 3B lightweight models recommended on $ramGB GB RAM." -ForegroundColor Yellow
+    } elseif ($ramGB -lt 8) {
+        Write-Host "  NOTE: $ramGB GB RAM is enough for 7B models. NemoMix 12B needs 8 GB." -ForegroundColor Yellow
+    }
+}
+Write-Host ""
 
 # =================================================================
 # STEP 1: MODEL SELECTION MENU
@@ -375,7 +390,7 @@ foreach ($m in $SelectedModels) {
             Write-Host "      Retry attempt $attempt..." -ForegroundColor Yellow
         }
 
-        curl.exe -L --ssl-no-revoke --progress-bar $m.URL -o $dest
+        curl.exe -L --progress-bar $m.URL -o $dest
 
         if (Test-DownloadedFile -Path $dest -MinSize $m.MinBytes) {
             $success = $true
@@ -441,7 +456,7 @@ $OllamaDest = "$USB_Drive\ollama\ollama-windows-amd64.zip"
 if (Test-Path "$USB_Drive\ollama\ollama.exe") {
     Write-Host "      Ollama already installed! Skipping..." -ForegroundColor Green
 } else {
-    curl.exe -L --ssl-no-revoke --progress-bar $OllamaURL -o $OllamaDest
+    curl.exe -L --progress-bar $OllamaURL -o $OllamaDest
 
     if (Test-Path $OllamaDest) {
         Write-Host "      Extracting Ollama..." -ForegroundColor Yellow
@@ -477,7 +492,7 @@ if (Test-Path $ExistingApp -PathType Leaf) {
     # Download the installer
     if (-Not (Test-Path $InstallerDest) -or (Get-Item $InstallerDest).Length -lt 10000000) {
         Write-Host "      Downloading installer..." -ForegroundColor Magenta
-        curl.exe -L --ssl-no-revoke --progress-bar $AnythingLLMURL -o $InstallerDest
+        curl.exe -L --progress-bar $AnythingLLMURL -o $InstallerDest
     }
 
     if (Test-Path $InstallerDest) {
@@ -550,7 +565,25 @@ if (-Not (Test-Path "$USB_Drive\ollama\ollama.exe")) {
         $ServerProcess = $null
         try {
             $ServerProcess = Start-Process -FilePath "$USB_Drive\ollama\ollama.exe" -ArgumentList "serve" -WindowStyle Hidden -PassThru
-            Start-Sleep -Seconds 5
+
+            # Poll for readiness (up to 30 s) so import doesn't start against a cold server.
+            Write-Host -NoNewline "      Waiting for engine to initialise"
+            $ollamaReady = $false
+            for ($wi = 0; $wi -lt 30; $wi++) {
+                try {
+                    Invoke-WebRequest -Uri "http://127.0.0.1:11434/api/tags" -UseBasicParsing -TimeoutSec 1 -ErrorAction Stop | Out-Null
+                    $ollamaReady = $true
+                    Write-Host " ready." -ForegroundColor Green
+                    break
+                } catch {
+                    Write-Host -NoNewline "."
+                    Start-Sleep -Seconds 1
+                }
+            }
+            if (-not $ollamaReady) {
+                Write-Host " timeout." -ForegroundColor Yellow
+                Write-Host "      Warning: Ollama did not respond within 30 seconds." -ForegroundColor Yellow
+            }
 
             foreach ($m in $modelsToImport) {
                 Write-Host "      Importing $($m.Name)..." -ForegroundColor Yellow
@@ -602,10 +635,16 @@ if (-Not (Test-Path $envFilePath)) {
     Set-Content -Path $envFilePath -Value $envContent -Force -Encoding UTF8
     Write-Host "      AnythingLLM configured to use: $firstModelLocal" -ForegroundColor Green
 } else {
-    # Update just the model preference if .env already exists
     $existing = Get-Content $envFilePath -Raw
     if ($existing -match 'LLM_PROVIDER=ollama') {
-        Write-Host "      AnythingLLM already configured for Ollama." -ForegroundColor Green
+        # Update OLLAMA_MODEL_PREF without rewriting the rest of the user's config.
+        if ($existing -match '(?m)^OLLAMA_MODEL_PREF=') {
+            $existing = [regex]::Replace($existing, '(?m)^OLLAMA_MODEL_PREF=.*', "OLLAMA_MODEL_PREF=$firstModelLocal")
+        } else {
+            $existing = $existing.TrimEnd() + "`r`nOLLAMA_MODEL_PREF=$firstModelLocal"
+        }
+        Set-Content -Path $envFilePath -Value $existing.TrimEnd() -Force -Encoding UTF8
+        Write-Host "      Updated OLLAMA_MODEL_PREF to: $firstModelLocal" -ForegroundColor Green
     } else {
         # Overwrite with correct config (user was using built-in ollama)
         Set-Content -Path $envFilePath -Value $envContent -Force -Encoding UTF8

--- a/linux/install-core.sh
+++ b/linux/install-core.sh
@@ -585,7 +585,13 @@ VECTOR_DB=lancedb
 EOF
     echo -e "${GREEN}      AnythingLLM configured to use: ${FIRST_LOCAL}${NC}"
 elif grep -q "LLM_PROVIDER=ollama" "$ENV_FILE"; then
-    echo -e "${GREEN}      AnythingLLM already configured for Ollama.${NC}"
+    # Update OLLAMA_MODEL_PREF without rewriting the rest of the user's config.
+    if grep -q "^OLLAMA_MODEL_PREF=" "$ENV_FILE"; then
+        sed -i "s|^OLLAMA_MODEL_PREF=.*|OLLAMA_MODEL_PREF=${FIRST_LOCAL}|" "$ENV_FILE"
+    else
+        echo "OLLAMA_MODEL_PREF=${FIRST_LOCAL}" >> "$ENV_FILE"
+    fi
+    echo -e "${GREEN}      Updated OLLAMA_MODEL_PREF to: ${FIRST_LOCAL}${NC}"
 else
     cat > "$ENV_FILE" <<EOF
 LLM_PROVIDER=ollama

--- a/linux/preflight-check.sh
+++ b/linux/preflight-check.sh
@@ -30,6 +30,8 @@ REC_WRITE_MBPS=25
 MIN_READ_MBPS=20
 REC_READ_MBPS=50
 BENCH_SIZE_MB=128
+MIN_RAM_GB=4
+REC_RAM_GB=8
 
 # ── Paths ─────────────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -360,13 +362,13 @@ echo -e "${CYAN}  ║       Verifying drive before installation...        ║${N
 echo -e "${CYAN}  ╚══════════════════════════════════════════════════════╝${NC}"
 echo ""
 echo -e "  ${DGRAY}Script Dir   : $SCRIPT_DIR${NC}"
-echo -e "  ${DGRAY}Minimum      : ${MIN_SPACE_GB} GB free  |  Write ≥ ${MIN_WRITE_MBPS} MB/s  |  Read ≥ ${MIN_READ_MBPS} MB/s${NC}"
-echo -e "  ${DGRAY}Recommended  : ${REC_SPACE_GB} GB free  |  Write ≥ ${REC_WRITE_MBPS} MB/s  |  Read ≥ ${REC_READ_MBPS} MB/s${NC}"
+echo -e "  ${DGRAY}Minimum      : ${MIN_SPACE_GB} GB free  |  Write ≥ ${MIN_WRITE_MBPS} MB/s  |  Read ≥ ${MIN_READ_MBPS} MB/s  |  RAM ≥ ${MIN_RAM_GB} GB${NC}"
+echo -e "  ${DGRAY}Recommended  : ${REC_SPACE_GB} GB free  |  Write ≥ ${REC_WRITE_MBPS} MB/s  |  Read ≥ ${REC_READ_MBPS} MB/s  |  RAM ≥ ${REC_RAM_GB} GB${NC}"
 
 # ================================================================
 # STEP 1 — DEPENDENCY CHECK
 # ================================================================
-section "Step 1 / 4 — Required Tools"
+section "Step 1 / 5 — Required Tools"
 echo ""
 
 MISSING_DEPS=()
@@ -388,7 +390,7 @@ fi
 # ================================================================
 # STEP 2 — USB DRIVE DETECTION
 # ================================================================
-section "Step 2 / 4 — USB Drive Detection"
+section "Step 2 / 5 — USB Drive Detection"
 echo ""
 
 if choose_from_mounted_usbs; then
@@ -497,7 +499,7 @@ fi
 # ================================================================
 # STEP 3 — DISK SPACE CHECK
 # ================================================================
-section "Step 3 / 4 — Available Disk Space"
+section "Step 3 / 5 — Available Disk Space"
 echo ""
 
 if [[ -z "$TARGET_MOUNT" || ! -d "$TARGET_MOUNT" ]]; then
@@ -542,9 +544,47 @@ echo -e "  ${DGRAY}│${NC}  ${DGRAY}Ollama engine + AppImage   ~1.0 GB   REQUIR
 echo -e "  ${DGRAY}└───────────────────────────────────────────────────────┘${NC}"
 
 # ================================================================
-# STEP 4 — DRIVE SPEED BENCHMARK
+# STEP 4 — SYSTEM RAM
 # ================================================================
-section "Step 4 / 4 — Drive Speed Benchmark"
+section "Step 4 / 5 — System RAM"
+echo ""
+
+TOTAL_RAM_KB=$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null || echo 0)
+AVAIL_RAM_KB=$(awk '/^MemAvailable:/{print $2}' /proc/meminfo 2>/dev/null || echo 0)
+TOTAL_RAM_GB=$(( TOTAL_RAM_KB / 1024 / 1024 ))
+AVAIL_RAM_GB=$(( AVAIL_RAM_KB / 1024 / 1024 ))
+
+echo -e "  ${DGRAY}┌─ Memory ──────────────────────────────────────────────┐${NC}"
+printf  "  ${DGRAY}│${NC}  %-16s ${BOLD}%d GB${NC}\n" "Total RAM:"  "$TOTAL_RAM_GB"
+printf  "  ${DGRAY}│${NC}  %-16s ${BOLD}%d GB${NC}\n" "Available:"  "$AVAIL_RAM_GB"
+echo -e "  ${DGRAY}└───────────────────────────────────────────────────────┘${NC}"
+echo ""
+
+if (( TOTAL_RAM_GB == 0 )); then
+  result_warn "Could not read system RAM from /proc/meminfo"
+elif (( TOTAL_RAM_GB >= REC_RAM_GB )); then
+  result_pass "RAM: ${TOTAL_RAM_GB} GB — sufficient for all preset models"
+elif (( TOTAL_RAM_GB >= 6 )); then
+  result_warn "RAM: ${TOTAL_RAM_GB} GB — enough for 7B models; NemoMix 12B requires ${REC_RAM_GB} GB"
+elif (( TOTAL_RAM_GB >= MIN_RAM_GB )); then
+  result_warn "RAM: ${TOTAL_RAM_GB} GB — only 3B lightweight models recommended"
+  result_info "7B models need ≥ 6 GB; NemoMix 12B needs ≥ ${REC_RAM_GB} GB"
+else
+  result_fail "RAM: ${TOTAL_RAM_GB} GB — insufficient (minimum ${MIN_RAM_GB} GB required)"
+  result_info "This system may not have enough RAM to run any AI model reliably"
+fi
+
+echo ""
+echo -e "  ${DGRAY}┌─ Model RAM Guide ─────────────────────────────────────┐${NC}"
+echo -e "  ${DGRAY}│${NC}  ${GREEN}Llama 3.2 3B / Phi-3.5 Mini${NC}      ≥ 4 GB RAM"
+echo -e "  ${DGRAY}│${NC}  ${CYAN}Mistral / Qwen / Dolphin 7-8B${NC}     ≥ 6 GB RAM"
+echo -e "  ${DGRAY}│${NC}  ${MAGENTA}NemoMix Unleashed 12B${NC}             ≥ 8 GB RAM"
+echo -e "  ${DGRAY}└───────────────────────────────────────────────────────┘${NC}"
+
+# ================================================================
+# STEP 5 — DRIVE SPEED BENCHMARK
+# ================================================================
+section "Step 5 / 5 — Drive Speed Benchmark"
 echo ""
 echo -e "  ${DGRAY}Using a ${BENCH_SIZE_MB} MB temporary test file on:${NC}"
 echo -e "  ${DGRAY}${TARGET_MOUNT}${NC}"

--- a/linux/start-linux.sh
+++ b/linux/start-linux.sh
@@ -114,12 +114,48 @@ rm -rf "$ANYTHINGLLM_CACHE/Code Cache"            2>/dev/null || true
 rm -rf "$ANYTHINGLLM_CACHE/GPUCache"              2>/dev/null || true
 
 # -------------------------------------------------------
+# RAM ADVISORY
+# -------------------------------------------------------
+_RAM_KB=$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null || echo 0)
+_RAM_GB=$(( _RAM_KB / 1024 / 1024 ))
+if (( _RAM_GB > 0 && _RAM_GB < 4 )); then
+    echo -e "${RED}WARNING: Only ${_RAM_GB} GB RAM detected. AI models require at least 4 GB — expect crashes or very slow responses.${NC}"
+elif (( _RAM_GB > 0 && _RAM_GB < 6 )); then
+    echo -e "${YELLOW}NOTE: ${_RAM_GB} GB RAM. 7B+ models need 6 GB; NemoMix 12B needs 8 GB.${NC}"
+fi
+unset _RAM_KB _RAM_GB
+
+# -------------------------------------------------------
 # START OLLAMA ENGINE (background)
 # -------------------------------------------------------
 echo "Starting Ollama Engine..."
 OLLAMA_HOST="127.0.0.1:11434" "$OLLAMA_BIN" serve &>/dev/null &
 OLLAMA_PID=$!
-sleep 3   # give it time to bind
+
+# Poll until the API responds (up to 30 s) instead of a fixed sleep.
+# If Ollama OOMs on start-up it exits before the timeout and we can explain why.
+printf "Waiting for Ollama to be ready"
+_ollama_ready=false
+for (( _i=1; _i<=30; _i++ )); do
+    if curl -sf --max-time 1 "http://127.0.0.1:11434/api/tags" &>/dev/null; then
+        echo " ready."
+        _ollama_ready=true
+        break
+    fi
+    printf "."
+    sleep 1
+done
+if ! $_ollama_ready; then
+    echo " timeout."
+    if ! kill -0 "$OLLAMA_PID" 2>/dev/null; then
+        echo -e "${RED}ERROR: Ollama exited before becoming ready.${NC}"
+        echo "This usually means insufficient RAM for the selected model."
+        echo "NemoMix 12B requires at least 8 GB RAM; 7B models need at least 6 GB."
+        exit 1
+    fi
+    echo -e "${YELLOW}Warning: Ollama did not respond yet — it may still be initialising.${NC}"
+fi
+unset _ollama_ready _i
 
 # -------------------------------------------------------
 # START ANYTHINGLLM (foreground-launched, detached)

--- a/start-mac.command
+++ b/start-mac.command
@@ -46,9 +46,16 @@ if [ ! -d "$USB_DIR/anythingllm_mac/AnythingLLM.app" ]; then
     echo "First time setup: Downloading AnythingLLM directly to USB..."
     echo "NO installation on the Mac! Everything stays on the drive."
     mkdir -p "$USB_DIR/anythingllm_mac"
-    
+
+    # Select the correct build for this Mac's CPU — arm64 = Apple Silicon, x86_64 = Intel
+    if [ "$(uname -m)" = "arm64" ]; then
+        ANYTHINGLLM_DMG_URL="https://cdn.anythingllm.com/latest/AnythingLLMDesktop-Silicon.dmg"
+    else
+        ANYTHINGLLM_DMG_URL="https://cdn.anythingllm.com/latest/AnythingLLMDesktop.dmg"
+    fi
+
     # Download the DMG
-    curl -L --progress-bar "https://cdn.anythingllm.com/latest/AnythingLLMDesktop-Silicon.dmg" -o "$USB_DIR/anythingllm_mac/AnythingLLM_Installer.dmg"
+    curl -L --progress-bar "$ANYTHINGLLM_DMG_URL" -o "$USB_DIR/anythingllm_mac/AnythingLLM_Installer.dmg"
     
     echo "Extracting AnythingLLM to USB (please wait)..."
     # Mount the DMG silently and extract
@@ -72,6 +79,16 @@ fi
 # -----------------------------------------------------------------
 echo ""
 echo "Starting AI Engine from USB..."
+
+# Brief RAM advisory — Ollama OOM exits silently, so warn early
+_RAM_BYTES=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
+_RAM_GB=$(( _RAM_BYTES / 1073741824 ))
+if (( _RAM_GB > 0 && _RAM_GB < 4 )); then
+    echo "WARNING: Only ${_RAM_GB} GB RAM detected. AI models need at least 4 GB."
+elif (( _RAM_GB > 0 && _RAM_GB < 6 )); then
+    echo "NOTE: ${_RAM_GB} GB RAM. 7B+ models need 6 GB; NemoMix 12B needs 8 GB."
+fi
+unset _RAM_BYTES _RAM_GB
 
 # Lock all data paths to the USB drive
 export OLLAMA_MODELS="$DATA_DIR"
@@ -124,16 +141,38 @@ if [ -f "$USB_DIR/models/installed-models.txt" ]; then
 fi
 
 # Start Ollama in background
+OLLAMA_PID=""
 if [ -f "$MAC_OLLAMA_DIR/Ollama.app/Contents/MacOS/Ollama" ]; then
     "$MAC_OLLAMA_DIR/Ollama.app/Contents/MacOS/Ollama" serve > /dev/null 2>&1 &
+    OLLAMA_PID=$!
 elif [ -f "$MAC_OLLAMA_DIR/ollama" ]; then
     "$MAC_OLLAMA_DIR/ollama" serve > /dev/null 2>&1 &
+    OLLAMA_PID=$!
 else
     echo "Error: Could not find the Ollama binary on the USB drive!"
 fi
-OLLAMA_PID=$!
 
-sleep 3
+# Poll until the API responds (up to 30 s) instead of a fixed sleep.
+# If Ollama OOMs on start-up it exits before the timeout and we can explain why.
+printf "Waiting for Ollama to be ready"
+for _i in $(seq 1 30); do
+    if curl -sf --max-time 1 "http://127.0.0.1:11434/api/tags" &>/dev/null; then
+        echo " ready."
+        break
+    fi
+    printf "."
+    sleep 1
+    if [ "$_i" -eq 30 ]; then
+        echo " timeout."
+        if [ -n "$OLLAMA_PID" ] && ! kill -0 "$OLLAMA_PID" 2>/dev/null; then
+            echo ""
+            echo "ERROR: Ollama process exited before becoming ready."
+            echo "This usually means insufficient RAM for the selected model."
+            echo "NemoMix 12B requires at least 8 GB RAM; 7B models need at least 6 GB."
+        fi
+    fi
+done
+unset _i
 
 echo ""
 echo "==================================================="

--- a/start-windows.bat
+++ b/start-windows.bat
@@ -91,8 +91,14 @@ if exist "%~dp0models\installed-models.txt" (
 echo Starting Ollama Engine...
 start "" /B "%~dp0ollama\ollama.exe" serve
 
-:: Give it a few seconds to boot up
-timeout /t 3 >nul
+:: Poll until Ollama accepts connections (up to 30 s) instead of a fixed sleep.
+echo Waiting for Ollama to be ready...
+for /l %%i in (1,1,30) do (
+    curl.exe -sf --max-time 1 http://127.0.0.1:11434/api/tags >nul 2>&1
+    if not errorlevel 1 goto :ollama_ready
+    timeout /t 1 >nul
+)
+:ollama_ready
 
 :: Find and launch AnythingLLM
 echo Starting AnythingLLM Interface...


### PR DESCRIPTION
Resolves #49, #46, #60, #61, #62

### Summary

- **#49 — Intel Mac support**: `start-mac.command` now uses `uname -m` to
  select the correct AnythingLLM DMG (`-Silicon` vs plain) at first-run
  download time. Ollama's `ollama-darwin.zip` is already a universal binary
  and is unchanged.

- **#46 — RAM pre-flight check / OOM messaging**: `linux/preflight-check.sh`
  gains a dedicated Step 4/5 that reads `/proc/meminfo`, grades total RAM
  against per-model thresholds (4/6/8 GB), and fails the check if < 4 GB.
  The three launchers (`start-linux.sh`, `start-mac.command`,
  `install-core.ps1`) now emit an advisory line when available RAM is below
  the threshold for the installed models. If Ollama exits before the
  readiness poll completes, the launchers now print an actionable OOM
  message instead of silently hanging.

- **#60 — TLS revocation**: Removed `--ssl-no-revoke` from all three
  `curl.exe` calls in `install-core.ps1` (model files, Ollama binary,
  AnythingLLM installer). The flag disabled OCSP/CRL checking across all
  binary downloads, which is a meaningful security downgrade.

- **#61 — Ollama readiness poll**: Replaced every fixed `sleep`/`timeout`
  with a `curl`/`Invoke-WebRequest` loop that polls `GET /api/tags` once per
  second, up to 30 s. Returns as soon as the server is ready; prints a
  warning on timeout. Affects `start-linux.sh`, `start-mac.command`,
  `start-windows.bat`, and `install-core.ps1`. (`install-core.sh` already
  had a correct poll loop.)

- **#62 — `OLLAMA_MODEL_PREF` not updated on re-install**: Both
  `install-core.sh` and `install-core.ps1` now update only the
  `OLLAMA_MODEL_PREF` line in an existing `.env` via `sed -i` / regex
  replace. All other user settings (token limit, embedding engine, etc.) are
  preserved.

### Breaking changes

None. All changes are additive or remove a security downgrade.

### Notes for reviewers

- `--ssl-no-revoke` removal may surface failures in environments where OCSP
  endpoints are firewall-blocked. This is intentional; the correct fix there
  is to configure a trusted corporate CA, not to skip revocation globally.
- `OLLAMA_MODEL_PREF` is now always updated by the installer on re-runs.
  Users who manually changed the model in the AnythingLLM UI will have their
  preference overwritten the next time they run the installer. This is
  consistent with the documented behaviour ("re-run install.bat to add
  models") and matches what the first-time install already did.